### PR TITLE
Integrate Reusable Azure AI Translation Workflow from Central Repository

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -1,0 +1,28 @@
+name: Auto Translate
+
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for the branch that have not completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  translate:
+    name: 'Trigger Auto-Translate Workflow'
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: newfold-labs/workflows/.github/workflows/auto-translate.yml@main
+    with:
+      text_domain: 'wp-module-migration'
+    secrets:
+      TRANSLATOR_API_KEY: ${{ secrets.TRANSLATOR_API_KEY }}
+      NEWFOLD_ACCESS_TOKEN: ${{ secrets.NEWFOLD_ACCESS_TOKEN }}


### PR DESCRIPTION
## Proposed changes

This PR sets up the repository to use a centralized, reusable GitHub Actions workflow that automates localization file translation using **Azure AI Translation (Microsoft Translator)**.

### What’s Included
- Calls the reusable translation workflow from the central repository.
- Supports translation of `.po` and `.json` files with optional context stripping.
- Allows configuration of `text_domain`, defaulting to the repository name if not provided.

### Configuration Notes
- Triggers on push to `main` and via manual `workflow_dispatch`.
- Requires the following secrets:
  - `TRANSLATOR_API_KEY` (Azure AI Translation)
  - `NEWFOLD_ACCESS_TOKEN` (for creating pull requests)

This setup helps automate translation updates across repositories using a single, centralized translation logic.

### Documentation
[AI Translation Workflow Documentation](https://newfold-labs.github.io/how-we-work/5.13-ai-translation-workflow-documentation.html)