### PR TITLE
Add initial docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,4 +36,4 @@ composer run test
 
 ## Keeping documentation current
 
-When you change code, features, or workflows, update the docs. When adding or changing dependencies, update **docs/dependencies.md**. When cutting a release, update **docs/changelog.md**.
+When you change code, features, or workflows, update the docs. Keep **docs/index.md** current: when you add, remove, or rename doc files, update the table of contents (and quick links if present). When adding or changing dependencies, update **docs/dependencies.md**. When cutting a release, update **docs/changelog.md**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Agent guidance – wp-module-migration
+
+This file gives AI agents a quick orientation to the repo. For full detail, see the **docs/** directory.
+
+## What this project is
+
+- **wp-module-migration** – Initiates the migration process. Registers with the Newfold Module Loader; depends on instawp/connect-helpers and wp-module-loader. Maintained by Newfold Labs.
+
+- **Stack:** PHP 7.3+. See docs/dependencies.md.
+
+- **Architecture:** Registers with the loader; integrates with InstaWP connect-helpers for migration. See docs/integration.md.
+
+## Key paths
+
+| Purpose | Location |
+|---------|----------|
+| Bootstrap | `bootstrap.php` |
+| Includes | `includes/` |
+| Tests | `tests/` |
+
+## Essential commands
+
+```bash
+composer install
+composer run lint
+composer run fix
+composer run test
+```
+
+## Documentation
+
+- **Full documentation** is in **docs/**. Start with **docs/index.md**.
+- **CLAUDE.md** is a symlink to this file (AGENTS.md).
+
+---
+
+## Keeping documentation current
+
+When you change code, features, or workflows, update the docs. When adding or changing dependencies, update **docs/dependencies.md**. When cutting a release, update **docs/changelog.md**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,3 @@
+# Dependencies
+
+**Runtime:** instawp/connect-helpers, newfold-labs/wp-module-loader. **Dev:** johnpbloch/wordpress, lucatume/wp-browser, newfold-labs/wp-php-standards, phpunit/phpcov, wp-cli/i18n-command.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-migration
+title: Dependencies
+description: Composer and npm dependencies.
+updated: 2025-03-18
+---
+
 # Dependencies
 
 **Runtime:** instawp/connect-helpers, newfold-labs/wp-module-loader. **Dev:** johnpbloch/wordpress, lucatume/wp-browser, newfold-labs/wp-php-standards, phpunit/phpcov, wp-cli/i18n-command.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,3 @@
+# Development
+
+PHP: `composer run lint`, `composer run fix`. Tests: `composer run test`. When changing dependencies, update [dependencies.md](dependencies.md). When cutting a release, update **docs/changelog.md**.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-migration
+title: Development
+description: Lint, test, and workflow.
+updated: 2025-03-18
+---
+
 # Development
 
 PHP: `composer run lint`, `composer run fix`. Tests: `composer run test`. When changing dependencies, update [dependencies.md](dependencies.md). When cutting a release, update **docs/changelog.md**.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,12 @@
+# Getting started
+
+Prerequisites: PHP 7.3+, Composer. The module requires instawp/connect-helpers, wp-module-loader.
+
+```bash
+composer install
+composer run test
+composer run lint
+composer run fix
+```
+
+See [integration.md](integration.md) for using in a host plugin.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-migration
+title: Getting started
+description: Prerequisites, install, and run.
+updated: 2025-03-18
+---
+
 # Getting started
 
 Prerequisites: PHP 7.3+, Composer. The module requires instawp/connect-helpers, wp-module-loader.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,11 @@
+# wp-module-migration – Documentation index
+
+| Document | Description |
+|----------|-------------|
+| [overview.md](overview.md) | What the module does and who maintains it. |
+| [getting-started.md](getting-started.md) | Prerequisites, install, and tests. |
+| [integration.md](integration.md) | How the module registers and InstaWP integration. |
+| [development.md](development.md) | Lint, test, and workflow. |
+| [dependencies.md](dependencies.md) | Composer dependencies. |
+
+Root **AGENTS.md** gives a short agent summary and points here.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-migration
+title: Documentation index
+description: Table of contents and quick links.
+updated: 2025-03-18
+---
+
 # wp-module-migration – Documentation index
 
 | Document | Description |

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-migration
+title: Integration
+description: How the module registers and integrates.
+updated: 2025-03-18
+---
+
 # Integration
 
 The module registers with the Newfold Module Loader via bootstrap.php. It integrates with InstaWP connect-helpers for migration. The host plugin (e.g. onboarding) uses it to start migration flows. See [dependencies.md](dependencies.md).

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,3 @@
+# Integration
+
+The module registers with the Newfold Module Loader via bootstrap.php. It integrates with InstaWP connect-helpers for migration. The host plugin (e.g. onboarding) uses it to start migration flows. See [dependencies.md](dependencies.md).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,3 @@
+# Overview
+
+**wp-module-migration** initiates the migration process for Newfold WordPress sites. It registers with the Newfold Module Loader and uses instawp/connect-helpers and wp-module-loader. Used by onboarding and other flows. Maintained by Newfold Labs. Distributed via Newfold Satis.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-migration
+title: Overview
+description: What the module does and who maintains it.
+updated: 2025-03-18
+---
+
 # Overview
 
 **wp-module-migration** initiates the migration process for Newfold WordPress sites. It registers with the Newfold Module Loader and uses instawp/connect-helpers and wp-module-loader. Used by onboarding and other flows. Maintained by Newfold Labs. Distributed via Newfold Satis.


### PR DESCRIPTION
Adds AGENTS.md, CLAUDE.md (symlink to AGENTS.md), and docs/ per the Newfold modules documentation rollout: overview, getting-started, integration, development, and dependencies where applicable.

Made with [Cursor](https://cursor.com)