### PR TITLE
chore(i18n): align Composer i18n scripts with WP-CLI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,9 +64,8 @@
             "@i18n-json",
             "@i18n-php"
         ],
-        "i18n-json": "rm -f languages/*.json && vendor/bin/wp i18n make-json ./languages --no-purge --pretty-print",
-        "i18n-mo": "vendor/bin/wp i18n make-mo ./languages",
-        "i18n-php": "vendor/bin/wp i18n make-php ./languages",
+        "i18n-json": "rm -f languages/*.json && vendor/bin/wp i18n make-json ./languages --pretty-print",
+        "i18n-php": "vendor/bin/wp i18n make-php ./languages --pretty-print",
         "i18n-po": "vendor/bin/wp i18n update-po ./languages/wp-module-migration.pot ./languages",
         "i18n-pot": "vendor/bin/wp i18n make-pot . ./languages/wp-module-migration.pot --domain=wp-module-migration --headers='{\"Report-Msgid-Bugs-To\":\"https://github.com/newfold-labs/wp-module-migration/issues\",\"POT-Creation-Date\":\"2025-02-13T09:55:55+00:00\"}' --exclude=src,tests,wordpress",
         "lint": [
@@ -98,6 +97,15 @@
         }
     },
     "scripts-descriptions": {
+        "fix": "Automatically fix coding standards issues where possible.",
+        "i18n": "Run the full local i18n pipeline (POT, PO, PHP, JSON).",
+        "i18n-ci-pre": "CI: regenerate the POT file and sync PO catalogs from it.",
+        "i18n-ci-post": "CI: regenerate JED JSON and PHP translation files from PO catalogs.",
+        "i18n-json": "Remove stale JSON catalogs, then generate JED JSON from PO files using wp i18n make-json.",
+        "i18n-php": "Generate PHP translation files from PO files using wp i18n make-php.",
+        "i18n-po": "Update PO files from the POT file using wp i18n update-po.",
+        "i18n-pot": "Scan source and generate the POT translation template using wp i18n make-pot.",
+        "lint": "Check files against coding standards.",
         "test": "Run tests.",
         "test-coverage": "Run tests with coverage, merge coverage and create HTML report."
     }


### PR DESCRIPTION
## Summary
Align `composer.json` i18n scripts with current WP-CLI i18n behavior (org standardization).

## Changes
- Remove `--no-purge` from `wp i18n make-json` where present; keep `rm -f languages/*.json &&` before `make-json` (orphan Jed JSON cleanup).
- Add `--pretty-print` to `wp i18n make-php` where missing.
- Remove `i18n-mo` / `make-mo` and `@i18n-mo` from script chains.
- Add or refresh `scripts-descriptions` so every `scripts` entry is documented.

## Verification
- `composer validate`
- `composer run-script --list`