### PR TITLE
Refactor migration tracking to use wp_options

### DIFF
--- a/includes/Listeners/InstaWpOptionsUpdatesListener.php
+++ b/includes/Listeners/InstaWpOptionsUpdatesListener.php
@@ -98,6 +98,7 @@ class InstaWpOptionsUpdatesListener {
 							'migration_failed',
 							$this->tracker->get_track_content()
 						);
+						$this->tracker->delete_track();
 					} elseif ( 'aborted' === $migration_status ) {
 						$migration_complete = new LastStep();
 						$migration_complete->set_status( $migration_complete->statuses['aborted'] );
@@ -106,6 +107,7 @@ class InstaWpOptionsUpdatesListener {
 							'migration_aborted',
 							$this->tracker->get_track_content()
 						);
+						$this->tracker->delete_track();
 					}
 				}
 			}
@@ -211,6 +213,7 @@ class InstaWpOptionsUpdatesListener {
 
 				EventService::send_application_event( "migration_$status", $migration_infos );
 				update_option( 'nfd_migration_status_sent', true );
+				$this->tracker->delete_track();
 			}
 		}
 	}

--- a/includes/Services/InstaMigrateService.php
+++ b/includes/Services/InstaMigrateService.php
@@ -49,7 +49,7 @@ class InstaMigrateService {
 		);
 		$this->tracker->update_track( $instawp_get_key_step );
 		if ( ! $instawp_get_key_step->failed() ) {
-			$this->insta_api_key = $instawp_get_key_step->get_data( 'insta_api_key' );
+			$this->insta_api_key = $instawp_get_key_step->get_insta_api_key();
 		} else {
 			return new \WP_Error(
 				'Bad request',

--- a/includes/Services/Tracker.php
+++ b/includes/Services/Tracker.php
@@ -10,58 +10,28 @@ use NewfoldLabs\WP\Module\Migration\Steps\AbstractStep;
  */
 class Tracker {
 	/**
-	 * Name of the tracking file.
+	 * Option name for tracking data.
 	 *
-	 * @var string $file_name.
+	 * @var string
 	 */
-	protected $file_name = '.nfd-migration-tracking';
-	/**
-	 * Path to the tracker file.
-	 *
-	 * @var string $path.
-	 */
-	protected $path = ABSPATH;
+	const OPTION_NAME = 'nfd_migration_tracking';
+
 	/**
 	 * Get the current step status.
 	 *
 	 * @return array
 	 */
 	public function get_track_content() {
-		global $wp_filesystem;
-
-		// Make sure that the above variable is properly setup.
-		require_once ABSPATH . 'wp-admin/includes/file.php';
-		WP_Filesystem();
-
-		$file_path = $this->get_full_path();
-
-		if ( $wp_filesystem->exists( $file_path ) ) {
-			$track_content = $wp_filesystem->get_contents( $file_path );
-			$track_content = json_decode( $track_content, true );
-
-			if ( ! is_array( $track_content ) || empty( $track_content ) ) {
-				$track_content = array();
-			}
-		} else {
-			$track_content = array();
-		}
-
-		return $track_content;
+		return get_option( self::OPTION_NAME, array() );
 	}
 
 	/**
-	 * Update the tracking file with the current step status
+	 * Update the tracking data with the current step status
 	 *
 	 * @param AbstractStep $step the step to update.
 	 * @return bool
 	 */
 	public function update_track( AbstractStep $step ) {
-		global $wp_filesystem;
-
-		// Make sure that the above variable is properly setup.
-		require_once ABSPATH . 'wp-admin/includes/file.php';
-		WP_Filesystem();
-
 		$updated       = false;
 		$track_content = $this->get_track_content();
 		if ( $step && is_array( $track_content ) ) {
@@ -75,79 +45,27 @@ class Tracker {
 				),
 			);
 			$updated_track = array_replace( $track_content, $datas );
-			$updated       = $wp_filesystem->put_contents( $this->get_full_path(), wp_json_encode( $updated_track ) );
+			$updated       = update_option( self::OPTION_NAME, $updated_track );
 		}
 
 		return $updated;
 	}
 
 	/**
-	 * Remove the tracking file
+	 * Remove the tracking data
 	 *
 	 * @return bool
 	 */
 	public function delete_track() {
-		global $wp_filesystem;
-
-		// Make sure that the above variable is properly setup.
-		require_once ABSPATH . 'wp-admin/includes/file.php';
-		WP_Filesystem();
-		$deleted = false;
-		if ( $wp_filesystem->exists( $this->get_full_path() ) ) {
-			$deleted = wp_delete_file( $this->get_full_path() );
-		}
-
-		return $deleted;
+		return delete_option( self::OPTION_NAME );
 	}
 
 	/**
-	 * Reset the tracking file to an empty array to start from fresh.
+	 * Reset the tracking data to an empty array to start from fresh.
 	 *
 	 * @return bool
 	 */
 	public function reset() {
-		global $wp_filesystem;
-
-		// Make sure that the above variable is properly setup.
-		require_once ABSPATH . 'wp-admin/includes/file.php';
-		WP_Filesystem();
-
-		$path  = $this->get_full_path();
-		$reset = false;
-		if ( $wp_filesystem->exists( $path ) && $wp_filesystem->is_writable( $path ) ) {
-			$reset = $wp_filesystem->put_contents( $path, wp_json_encode( array() ) );
-		}
-
-		return $reset;
-	}
-
-	/**
-	 * Set the tracker file path.
-	 *
-	 * @param string $path the path to the tracker file.
-	 * @return void
-	 */
-	public function set_path( $path ) {
-		$path       = ! empty( $path ) ? $path : ABSPATH;
-		$this->path = $path;
-	}
-	/**
-	 * Set the tracker file name.
-	 *
-	 * @param string $file_name the name of the tracker file.
-	 * @return void
-	 */
-	public function set_file_name( $file_name ) {
-		$file_name       = ! empty( $file_name ) ? $file_name : '.nfd-migration-tracking';
-		$this->file_name = $file_name;
-	}
-
-	/**
-	 * Get the tracker file path.
-	 *
-	 * @return string
-	 */
-	private function get_full_path() {
-		return $this->path . $this->file_name;
+		return update_option( self::OPTION_NAME, array() );
 	}
 }

--- a/includes/Steps/ConnectToInstaWp.php
+++ b/includes/Steps/ConnectToInstaWp.php
@@ -84,15 +84,4 @@ class ConnectToInstaWp extends AbstractStep {
 			$this->success();
 		}
 	}
-
-	/**
-	 * Set the step as successful and store the API key.
-	 *
-	 * @return void
-	 */
-	protected function success() {
-		parent::success();
-
-		$this->set_data( 'ApiKey', Helper::get_api_key() );
-	}
 }

--- a/includes/Steps/GetInstaWpApiKey.php
+++ b/includes/Steps/GetInstaWpApiKey.php
@@ -47,7 +47,6 @@ class GetInstaWpApiKey extends AbstractStep {
 		if ( ! $this->insta_api_key ) {
 			$this->insta_api_key = UtilityService::get_insta_api_key( BRAND_PLUGIN );
 			if ( $this->insta_api_key ) {
-				$this->set_data( 'insta_api_key', $this->insta_api_key );
 				update_option( 'newfold_insta_api_key', $this->encrypter->encrypt( $this->insta_api_key ) );
 				$this->success();
 			} else {
@@ -59,8 +58,16 @@ class GetInstaWpApiKey extends AbstractStep {
 				);
 			}
 		} else {
-			$this->set_data( 'insta_api_key', $this->insta_api_key );
 			$this->success();
 		}
+	}
+
+	/**
+	 * Get the InstaWP API key.
+	 *
+	 * @return string
+	 */
+	public function get_insta_api_key() {
+		return $this->insta_api_key;
 	}
 }


### PR DESCRIPTION
## Proposed changes

Refactors the migration step tracker to use `wp_options` instead of a filesystem-based approach. Simplifies the `Tracker` class and removes unnecessary file I/O.

- Replaced file read/write with `get_option` / `update_option` / `delete_option`
- Removed unused file path helpers (`set_path`, `set_file_name`, `get_full_path`)
- Cleaned up step data that was being tracked but never consumed downstream
- Added cleanup of tracking data after migration completes, fails, or is aborted

## Type of Change

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [x] Refactoring / housekeeping (changes to files not directly related to functionality)

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)